### PR TITLE
SFTP: Switch to latest image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: helm-docs
-helm-docs:
-	# go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.10.0
-	helm-docs
+.PHONY: all
+all: tests helm-docs
 
 .PHONY: tests
 tests:
 	./scripts/test.sh
+
+.PHONY: helm-docs
+helm-docs:
+	# go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.10.0
+	helm-docs

--- a/charts/sftp-server/Chart.yaml
+++ b/charts/sftp-server/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: sftp-server
 description: A Helm chart for https://github.com/atmoz/sftp
 type: application
-version: 0.1.3
+version: 0.1.4
 sources: ["https://github.com/sj14/helm-charts"]

--- a/charts/sftp-server/README.md
+++ b/charts/sftp-server/README.md
@@ -1,6 +1,6 @@
 # sftp-server
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for https://github.com/atmoz/sftp
 
@@ -24,8 +24,8 @@ helm upgrade sftp --install sj14/sftp-server
 | extraInitContainers | list | `[]` | Additional Init containers of the pod. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/atmoz/sftp/alpine@sha256"` |  |
-| image.tag | string | `"688d93138e4d8c1b6401c9d8be5ec4b6153bdce4a7322ce4d7349ba75b6845f8"` |  |
+| image.repository | string | `"ghcr.io/atmoz/sftp/alpine"` |  |
+| image.tag | string | `"latest"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/sftp-server/tests/outputs/custom.yaml
+++ b/charts/sftp-server/tests/outputs/custom.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -20,7 +20,7 @@ kind: ConfigMap
 metadata:
   name: release-name-sftp-server-auth-demo
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -35,7 +35,7 @@ kind: ConfigMap
 metadata:
   name: release-name-sftp-server-auth-traffic
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -50,7 +50,7 @@ kind: ConfigMap
 metadata:
   name: release-name-sftp-server-users
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ kind: Service
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -86,7 +86,7 @@ kind: Deployment
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -99,9 +99,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 4adf7a1d2090c43296d1303eacbcd5c5facfb9e3ab7830907d4e41a2594d3be4
-        checksum/config-keys: ebdc9c6c9fd2ef3a4c7e76f226f29afaebc12a18b8edbd7b8515b6acf1981a69
-        checksum/host-keys: 4046f97851a113ed521ee39aad805392f6a84abd5e9febdaa9eb024ba14aa516
+        checksum/config-users: 7e3171bf2c1967c1f23473710417375359075fac1e9bde975f405a0be8ed6597
+        checksum/config-keys: cc2a077cf3e6fb3d8f484975db12a4faf4d6a81cddd9711b9881f03ace4d267e
+        checksum/host-keys: 78c4a4486a91c10c9b480b7a1e915e46286ecfaf73f502f85629dc9174b04581
       labels:
         app.kubernetes.io/name: sftp-server
         app.kubernetes.io/instance: release-name
@@ -116,7 +116,7 @@ spec:
         - name: sftp-server
           securityContext:
             {}
-          image: "ghcr.io/atmoz/sftp/alpine@sha256:688d93138e4d8c1b6401c9d8be5ec4b6153bdce4a7322ce4d7349ba75b6845f8"
+          image: "ghcr.io/atmoz/sftp/alpine:latest"
           imagePullPolicy: IfNotPresent
           ports:
             - name: ssh

--- a/charts/sftp-server/tests/outputs/empty.yaml
+++ b/charts/sftp-server/tests/outputs/empty.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -18,7 +18,7 @@ kind: ConfigMap
 metadata:
   name: release-name-sftp-server-users
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ kind: Service
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -53,7 +53,7 @@ kind: Deployment
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -66,9 +66,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 21302ecf1251307187b19c234334a43059ec87292e0a49087fb617788b770804
+        checksum/config-users: bf82db7525f41a8360cc98eadb864063bad6fdce04c4d55e4076965baa8fd6ae
         checksum/config-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/host-keys: d2034cdc8e0741317600864821840012c709b51fe39f3dc36b08d6af1db5a7d8
+        checksum/host-keys: 7d69f0767cab70d9cf272d25783357ff71fd15194cb3b61d62619f905b33da3c
       labels:
         app.kubernetes.io/name: sftp-server
         app.kubernetes.io/instance: release-name
@@ -81,7 +81,7 @@ spec:
         - name: sftp-server
           securityContext:
             {}
-          image: "ghcr.io/atmoz/sftp/alpine@sha256:688d93138e4d8c1b6401c9d8be5ec4b6153bdce4a7322ce4d7349ba75b6845f8"
+          image: "ghcr.io/atmoz/sftp/alpine:latest"
           imagePullPolicy: IfNotPresent
           ports:
             - name: ssh

--- a/charts/sftp-server/tests/outputs/persistent.yaml
+++ b/charts/sftp-server/tests/outputs/persistent.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -18,7 +18,7 @@ kind: ConfigMap
 metadata:
   name: release-name-sftp-server-users
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -32,7 +32,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -49,7 +49,7 @@ kind: Service
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -70,7 +70,7 @@ kind: Deployment
 metadata:
   name: release-name-sftp-server
   labels:
-    helm.sh/chart: sftp-server-0.1.3
+    helm.sh/chart: sftp-server-0.1.4
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
@@ -83,9 +83,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 21302ecf1251307187b19c234334a43059ec87292e0a49087fb617788b770804
+        checksum/config-users: bf82db7525f41a8360cc98eadb864063bad6fdce04c4d55e4076965baa8fd6ae
         checksum/config-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/host-keys: d2034cdc8e0741317600864821840012c709b51fe39f3dc36b08d6af1db5a7d8
+        checksum/host-keys: 7d69f0767cab70d9cf272d25783357ff71fd15194cb3b61d62619f905b33da3c
       labels:
         app.kubernetes.io/name: sftp-server
         app.kubernetes.io/instance: release-name
@@ -98,7 +98,7 @@ spec:
         - name: sftp-server
           securityContext:
             {}
-          image: "ghcr.io/atmoz/sftp/alpine@sha256:688d93138e4d8c1b6401c9d8be5ec4b6153bdce4a7322ce4d7349ba75b6845f8"
+          image: "ghcr.io/atmoz/sftp/alpine:latest"
           imagePullPolicy: IfNotPresent
           ports:
             - name: ssh

--- a/charts/sftp-server/values.yaml
+++ b/charts/sftp-server/values.yaml
@@ -6,9 +6,9 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/atmoz/sftp/alpine@sha256
+  repository: ghcr.io/atmoz/sftp/alpine
   pullPolicy: IfNotPresent
-  tag: "688d93138e4d8c1b6401c9d8be5ec4b6153bdce4a7322ce4d7349ba75b6845f8"  # build from 2022-06-10
+  tag: "latest"
 
 sftp:
   hostKeys:


### PR DESCRIPTION
artifacthub.io is showing security issues for the currently used image.
Switch to the `latest` tag as I don't want to update the tag everytime there is an issue.