### PR TITLE
Allow external keys

### DIFF
--- a/charts/sftp-server/templates/secret.yaml
+++ b/charts/sftp-server/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sftpExternalSecret }}
 {{- if .Values.sftp.hostKeys }}
 ---
 apiVersion: v1
@@ -14,4 +15,5 @@ data:
   {{- if .Values.sftp.hostKeys.rsa }}
   ssh_host_rsa_key: {{ .Values.sftp.hostKeys.rsa | b64enc }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
We don't want to store the keys inside the values but supply them as existing secret objects. This change makes that possible.