### PR TITLE
SFTP: Allow annotations in service

### DIFF
--- a/charts/sftp-server/README.md
+++ b/charts/sftp-server/README.md
@@ -48,6 +48,7 @@ helm upgrade sftp --install sj14/sftp-server
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
+| service.annotations | object | `{}` | Annotations to add to the service |
 | service.externalTraffic.enabled | bool | `false` | externalTrafficPolicy ([Kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)) |
 | service.externalTraffic.policy | string | `"Local"` |  |
 | service.loadBalancerIP | int | `0` | When using the LoadBalancer type. |

--- a/charts/sftp-server/README.md
+++ b/charts/sftp-server/README.md
@@ -54,7 +54,6 @@ helm upgrade sftp --install sj14/sftp-server
 | service.nodePort | int | `0` | When using the NodePort type, you can specify a fixed port ([Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)) |
 | service.port | int | `22` |  |
 | service.type | string | `"ClusterIP"` |  |
-| service.annotations | object | `{}` | Annotations to add to the service |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |

--- a/charts/sftp-server/README.md
+++ b/charts/sftp-server/README.md
@@ -54,6 +54,7 @@ helm upgrade sftp --install sj14/sftp-server
 | service.nodePort | int | `0` | When using the NodePort type, you can specify a fixed port ([Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)) |
 | service.port | int | `22` |  |
 | service.type | string | `"ClusterIP"` |  |
+| service.annotations | object | `{}` | Annotations to add to the service |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |

--- a/charts/sftp-server/templates/service.yaml
+++ b/charts/sftp-server/templates/service.yaml
@@ -4,10 +4,6 @@ metadata:
   name: {{ include "sftp-server.fullname" . }}
   labels:
     {{- include "sftp-server.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if $.Values.service.externalTraffic.enabled }}

--- a/charts/sftp-server/templates/service.yaml
+++ b/charts/sftp-server/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "sftp-server.fullname" . }}
   labels:
     {{- include "sftp-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if $.Values.service.externalTraffic.enabled }}

--- a/charts/sftp-server/tests/outputs/custom.yaml
+++ b/charts/sftp-server/tests/outputs/custom.yaml
@@ -69,6 +69,8 @@ metadata:
     app.kubernetes.io/name: sftp-server
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    my: annotation
 spec:
   type: ClusterIP
   externalTrafficPolicy: Local

--- a/charts/sftp-server/tests/values/custom.yaml
+++ b/charts/sftp-server/tests/values/custom.yaml
@@ -42,5 +42,7 @@ extraVolumeMounts:
     mountPath: /my-config/
 
 service:
+  annotations:
+    my: annotation
   externalTraffic:
     enabled: true

--- a/charts/sftp-server/values.yaml
+++ b/charts/sftp-server/values.yaml
@@ -123,6 +123,8 @@ service:
     # -- externalTrafficPolicy ([Kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip))
     enabled: false
     policy: "Local"
+  # -- Annotations to add to the service
+  annotations: {}
 
 resources: {}
   # limits:


### PR DESCRIPTION
I use [MetalLB](https://metallb.universe.tf/) where I need to annotate e.g. `metallb.universe.tf/loadBalancerIPs`.

```yaml
apiVersion: v1
kind: Service
metadata:
  name: sftp
  annotations:
    metallb.universe.tf/loadBalancerIPs: 192.168.1.100
```

Right now this is not directly possible.
