### PR TITLE
SFTP: Allow to configure users via a secret

### DIFF
--- a/charts/sftp-server/README.md
+++ b/charts/sftp-server/README.md
@@ -64,6 +64,7 @@ helm upgrade sftp --install sj14/sftp-server
 | sftp.hostKeys.rsa | object | `{"key":"","secretKeyRef":""}` | private RSA host key. Choose between adding the key itself or reference a already existing key. |
 | sftp.hostKeys.rsa.key | string | `""` | The plain key |
 | sftp.hostKeys.rsa.secretKeyRef | string | `""` | Reference to and existing secret with an "ssh_host_rsa_key" data key and base64 encrypted value. |
+| sftp.usersSecret | string | `""` | Reference to and existing secret that provides users' configuration. If present takes precedence over `.Values.sftp.users` configuration, whose schema is expected to use within a `users.conf` key  |
 | sftp.users[0].dirs[0] | string | `"upload"` |  |
 | sftp.users[0].gid | string | `""` |  |
 | sftp.users[0].name | string | `"demo"` |  |

--- a/charts/sftp-server/templates/_helpers.tpl
+++ b/charts/sftp-server/templates/_helpers.tpl
@@ -60,3 +60,20 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get users from configuration
+*/}}
+{{- define "sftp-server.getUsers" -}}
+{{- $users := .Values.sftp.users }}
+{{- if .Values.sftp.usersSecret }}
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.sftp.usersSecret -}}
+  {{- $secretKey := "users.conf" }}
+  {{- if and $secret (hasKey $secret "data") (hasKey $secret.data $secretKey) }}
+    {{- $users = fromYamlArray (index $secret.data $secretKey | b64dec) -}}
+  {{- else }}
+    {{- fail (printf "Secret '%s' does not exist or does not contain the expected key: %s" .Values.sftp.usersSecret $secretKey) }}
+  {{- end }}
+{{- end }}
+{{- $users | toYaml -}}
+{{- end }}

--- a/charts/sftp-server/templates/config-keys.yaml
+++ b/charts/sftp-server/templates/config-keys.yaml
@@ -1,4 +1,6 @@
-{{- range $i, $user := .Values.sftp.users }}
+{{- $users := include "sftp-server.getUsers" . | fromYamlArray }}
+
+{{- range $i, $user := $users }}
 {{- if $user.pubKeys }}
 ---
 apiVersion: v1

--- a/charts/sftp-server/templates/config-users.yaml
+++ b/charts/sftp-server/templates/config-users.yaml
@@ -1,3 +1,5 @@
+{{- $users := include "sftp-server.getUsers" . | fromYamlArray }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,6 +8,6 @@ metadata:
     {{- include "sftp-server.labels" . | nindent 4 }}
 data:
   users.conf: |
-  {{- range $i, $user := .Values.sftp.users }}
+  {{- range $i, $user := $users }}
     {{ $user.name }}:{{ $user.pass }}:{{ if $user.passEncrypted }}e:{{ end }}{{ $user.uid}}:{{ $user.gid }}:{{ join "," $user.dirs }}
   {{- end }}

--- a/charts/sftp-server/templates/deployment.yaml
+++ b/charts/sftp-server/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $users := include "sftp-server.getUsers" . | fromYamlArray }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -87,14 +89,14 @@ spec:
               mountPath: /etc/ssh/ssh_host_rsa_key
               subPath: ssh_host_rsa_key
             {{- end }}
-            {{- range $i, $user := .Values.sftp.users }}
+            {{- range $i, $user := $users }}
             {{- if $user.pubKeys }}
             - name: config-auth-{{ $user.name }}
               mountPath: "/home/{{ $user.name }}/.ssh/keys"
             {{- end }}
             {{- end }}
             {{- if .Values.persistentVolume.enabled }}
-            {{- range $i, $user := .Values.sftp.users }}
+            {{- range $i, $user := $users }}
             - name: storage-volume
               mountPath: "/home/{{ $user.name }}"
               subPath: "{{ $.Values.persistentVolume.subPath }}/{{ $user.name }}"
@@ -128,7 +130,7 @@ spec:
           secretName: {{ .Values.sftp.hostKeys.rsa.secretKeyRef }}
           defaultMode: 0400
       {{- end }}
-      {{- range $i, $user := .Values.sftp.users }}
+      {{- range $i, $user := $users }}
       {{- if $user.pubKeys }}
       - name: config-auth-{{ $user.name }}
         configMap:

--- a/charts/sftp-server/tests/outputs/custom.yaml
+++ b/charts/sftp-server/tests/outputs/custom.yaml
@@ -105,7 +105,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 4d68f819641e6054bd3a67f943eb97d34b2bacee919283f8ad35bee4ae8a981d
+        checksum/config-users: 7a8ad06a1e1ae080a5e37b3371a2790f1b7f3547e46d0e3c1f19d3132f943500
         checksum/config-keys: d42cfc9ad6ef93a797358a6c230c2ddc615d49d472ecf24c99643698c4ae2e24
         checksum/host-keys: 571e3cdaf8cb09754004f517709fba317f1f8c046bae1ab6c36a3ffa299c1f33
       labels:

--- a/charts/sftp-server/tests/outputs/empty.yaml
+++ b/charts/sftp-server/tests/outputs/empty.yaml
@@ -56,7 +56,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 584d8ff89167f8b94b84b60228af48c879d7d7b3f5fbd3d8e72a8f7f4ae7a7f2
+        checksum/config-users: 0259aefe687708b42bd1f2b848a0011d9d14c8d60c716d9e3a8896cb034de392
         checksum/config-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/host-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:

--- a/charts/sftp-server/tests/outputs/extraManifests.yaml
+++ b/charts/sftp-server/tests/outputs/extraManifests.yaml
@@ -72,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 584d8ff89167f8b94b84b60228af48c879d7d7b3f5fbd3d8e72a8f7f4ae7a7f2
+        checksum/config-users: 0259aefe687708b42bd1f2b848a0011d9d14c8d60c716d9e3a8896cb034de392
         checksum/config-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/host-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:

--- a/charts/sftp-server/tests/outputs/nodePort.yaml
+++ b/charts/sftp-server/tests/outputs/nodePort.yaml
@@ -57,7 +57,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 584d8ff89167f8b94b84b60228af48c879d7d7b3f5fbd3d8e72a8f7f4ae7a7f2
+        checksum/config-users: 0259aefe687708b42bd1f2b848a0011d9d14c8d60c716d9e3a8896cb034de392
         checksum/config-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/host-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:

--- a/charts/sftp-server/tests/outputs/persistent.yaml
+++ b/charts/sftp-server/tests/outputs/persistent.yaml
@@ -73,7 +73,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 584d8ff89167f8b94b84b60228af48c879d7d7b3f5fbd3d8e72a8f7f4ae7a7f2
+        checksum/config-users: 0259aefe687708b42bd1f2b848a0011d9d14c8d60c716d9e3a8896cb034de392
         checksum/config-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/host-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:

--- a/charts/sftp-server/tests/outputs/secretKeyRef.yaml
+++ b/charts/sftp-server/tests/outputs/secretKeyRef.yaml
@@ -56,7 +56,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config-users: 584d8ff89167f8b94b84b60228af48c879d7d7b3f5fbd3d8e72a8f7f4ae7a7f2
+        checksum/config-users: 0259aefe687708b42bd1f2b848a0011d9d14c8d60c716d9e3a8896cb034de392
         checksum/config-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/host-keys: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       labels:

--- a/charts/sftp-server/values.yaml
+++ b/charts/sftp-server/values.yaml
@@ -24,6 +24,13 @@ sftp:
       key: ""
       # -- Reference to and existing secret with an "ssh_host_rsa_key" data key and base64 encrypted value.
       secretKeyRef: ""
+
+  # -- Reference to and existing secret that provides users' configuration.
+  # If present takes precedence over `.Values.sftp.users` configuration,
+  # whose schema is expected to use within a `users.conf` key 
+  usersSecret: ""
+
+  # Array based configuration of users 
   users:
     - name: demo
       pass: demo


### PR DESCRIPTION
# What this PR wants to bring

As title, I wonder if could be useful to configure the chart via a K8s secret that uses the same exact configuration as the one provided by `.Values.sftp.users`. If present, the secret would take the precedence.

For example, instead of doing this:

```
---
# Default values for sftp.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.
[...]
sftp:
  # Array based configuration of users 
  users:
    - name: demo
      pass: demo
      # -- password is encrypted ([doc](https://github.com/atmoz/sftp/blob/ffeb104beec76cc622abda34ee2132c790b5559c/README.md#encrypted-password))
      passEncrypted: false
      uid: ""
      gid: ""
      dirs:
        - upload
      # -- public user keys ([doc](https://github.com/atmoz/sftp/blob/ffeb104beec76cc622abda34ee2132c790b5559c/README.md#logging-in-with-ssh-keys))
      pubKeys: []
```

We could alternatively get users' configuration from a `my-users-config` pre-existing secret in the following way:

```
# Default values for sftp.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.
[...]
sftp:
    # -- Reference to and existing secret that provides users' configuration.
  # If present takes precedence over `.Values.sftp.users` configuration,
  # whose schema is expected to use within a `users.conf` key 
  usersSecret: "my-users-config"

    # Set as empty array but could be left as it is with its default values
  users: {}
```

The `my-users-config` secret would be like this (please notice that I'm reading from a `users.conf` key):

```
➜  kubectl get secret my-users-config -o jsonpath='{.data.users\.conf}' | base64 -d
- name: demo
  pass: demo
  # -- password is encrypted ([doc](https://github.com/atmoz/sftp/blob/ffeb104beec76cc622abda34ee2132c790b5559c/README.md#encrypted-password))
  passEncrypted: false
  uid: ""
  gid: ""
  dirs:
    - upload
  # -- public user keys ([doc](https://github.com/atmoz/sftp/blob/ffeb104beec76cc622abda34ee2132c790b5559c/README.md#logging-in-with-ssh-keys))
      pubKeys: []
``` 

# Please note
The code can be refactored as you may feel best to do. Additionally I have not updated the tests, but it won't be a problem to manage them if necessary :)
